### PR TITLE
Refactor checks whether connections should be established 

### DIFF
--- a/extras/userdoc/md/documentation/installation.md
+++ b/extras/userdoc/md/documentation/installation.md
@@ -13,9 +13,9 @@ For more generic installation instructions, see the `INSTALL` file in the top so
 Following are the basic steps to compile and install NEST from source code:
 
 1.  [Download NEST](download.md)
-1.  Unpack the tarball: `tar -xzvf nest-x.y.z.tar.gz`
-1.  Create a build directory: `mkdir nest-x.y.z-build`
-1.  Change to the build directory: `cd nest-x.y.z-build`
+1.  Unpack the tarball: `tar -xzvf nest-simulator-x.y.z.tar.gz`
+1.  Create a build directory: `mkdir nest-simulator-x.y.z-build`
+1.  Change to the build directory: `cd nest-simulator-x.y.z-build`
 1.  Configure NEST: `cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> </path/to/NEST/src>` with
 additional `cmake` options as needed (see `INSTALL` file; `/install/path` should be an
 absolute path)
@@ -170,11 +170,11 @@ Installation instructions here have been tested under OS X 10.11 *El Capitan* an
 
 4.  Create a directory for building and installing NEST (you should always build NEST outside the source code directory; installing NEST in a "place of its own" makes it easy to remove NEST later).
 
-5.  Extract the NEST tarball as a subdirectory in that directory or clone NEST from Github into a subdirectory. 
+5.  Extract the NEST tarball as a subdirectory in that directory or clone NEST from GitHub into a subdirectory. 
 
         mkdir NEST       # directory for all NEST stuff
         cd NEST
-        tar zxf nest-2.14.0.tar.gz
+        tar zxf nest-simulator-x.y.z.tar.gz
         mkdir bld
         cd bld
 
@@ -256,13 +256,13 @@ Following are the basic steps to compile and install NEST from source code:
 
 1.  [Download NEST](download.md)
 
-2.  Unpack the tarball: `tar -xzvf nest-x.y.z.tar.gz`
+2.  Unpack the tarball: `tar -xzvf nest-simulator-x.y.z.tar.gz`
 
-3.  Create a build directory: `mkdir nest-x.y.z-build`
+3.  Create a build directory: `mkdir nest-simulator-x.y.z-build`
 
-4.  Change to the build directory: `cd nest-x.y.z-build`
+4.  Change to the build directory: `cd nest-simulator-x.y.z-build`
 
-5.  Configure NEST: `../nest-x.y.z/configure` with appropriate
+5.  Configure NEST: `../nest-simulator-x.y.z/configure` with appropriate
      configuration options
 
 6.  Compile by running `make`
@@ -315,11 +315,11 @@ and parallel computing facilities will be disabled.
 To compile NEST without external packages, use the following command line to
 configure it:
 
-    tar -xzvf nest-x.y.z.tar.gz
-    mkdir nest-x.y.z-build
-    cd nest-x.y.z-build
+    tar -xzvf nest-simulator-x.y.z.tar.gz
+    mkdir nest-simulator-x.y.z-build
+    cd nest-simulator-x.y.z-build
 
-    ../nest-x.y.z/configure
+    ../nest-simulator-x.y.z/configure
         --prefix=$HOME/opt/nest
         --without-python
         --without-readline
@@ -336,7 +336,7 @@ command line:
 
 Then configure NEST using:
 
-    ../nest-x.y.z/configure --prefix=$HOME/opt/nest
+    ../nest-simulator-x.y.z/configure --prefix=$HOME/opt/nest
 
 ## Configuration options
 
@@ -361,7 +361,7 @@ then crash Python. Either make sure that gcc and g++ are the system compiler,
 or force compilation with the system compiler, configure like this (append any
 other configure options):
 
-    ../nest-x.y.z/configure CC=/usr/bin/gcc CXX=/usr/bin/g++
+    ../nest-simulator-x.y.z/configure CC=/usr/bin/gcc CXX=/usr/bin/g++
 
 #### MPI issues
 

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -169,6 +169,16 @@ public:
   void
   disconnect( Node& target, index sgid, thread target_thread, index syn_id );
 
+
+  /**
+   * Check whether a connection between the given source and target
+   * nodes has to be established on the given thread with id tid.
+   *
+   * \returns true if the connection should be made, false otherwise.
+   */
+  bool
+  connection_required(Node*& source, Node*& target, thread tid);
+
   /**
    * Connect, using a dictionary with arrays.
    * The connection rule is based on the details of the dictionary entries

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -410,7 +410,7 @@ NodeManager::get_node_or_proxy( index gid )
   thread vp = kernel().vp_manager.suggest_vp( gid );
   if ( not kernel().vp_manager.is_local_vp( vp ) )
   {
-    return 0;
+    return kernel().model_manager.get_proxy_node( 0, gid );
   }
 
   thread t = kernel().vp_manager.vp_to_thread( vp );

--- a/nestkernel/proxynode.h
+++ b/nestkernel/proxynode.h
@@ -107,6 +107,11 @@ public:
 
   bool is_proxy() const;
 
+  thread get_thread() const
+  {
+    assert( false );
+  }
+
 private:
   void
   init_state_( const Node& )

--- a/topology/connection_creator_impl.h
+++ b/topology/connection_creator_impl.h
@@ -219,7 +219,7 @@ ConnectionCreator::target_driven_connect_( Layer< D >& source,
     const int thread_id = kernel().vp_manager.get_thread_id();
     try
     {
-      GIDCollection::const_iterator target_begin = target_gc->local_begin();
+      GIDCollection::const_iterator target_begin = target_gc->begin();
       GIDCollection::const_iterator target_end = target_gc->end();
 
       for ( GIDCollection::const_iterator tgt_it = target_begin;
@@ -229,23 +229,24 @@ ConnectionCreator::target_driven_connect_( Layer< D >& source,
         Node* const tgt =
           kernel().node_manager.get_node_or_proxy( ( *tgt_it ).gid, thread_id );
 
-        assert( not tgt->is_proxy() );
-
-        const Position< D > target_pos = target.get_position( ( *tgt_it ).lid );
-
-        if ( mask_.valid() )
+	if ( not tgt->is_proxy() )
         {
-          connect_to_target_( pool.masked_begin( target_pos ),
-            pool.masked_end(),
-            tgt,
-            target_pos,
-            thread_id,
-            source );
-        }
-        else
-        {
-          connect_to_target_(
-            pool.begin(), pool.end(), tgt, target_pos, thread_id, source );
+          const Position< D > target_pos = target.get_position( ( *tgt_it ).lid );
+
+          if ( mask_.valid() )
+          {
+            connect_to_target_( pool.masked_begin( target_pos ),
+              pool.masked_end(),
+              tgt,
+              target_pos,
+              thread_id,
+              source );
+          }
+          else
+          {
+            connect_to_target_(
+              pool.begin(), pool.end(), tgt, target_pos, thread_id, source );
+          }
         }
       } // for target_begin
     }


### PR DESCRIPTION
This PR removes the checks for whether a connection should be established between two nodes from the individual connection routines and adds them again as helper function `connection_required()` to the `ConnectionManager`. Additionally, the checks are now cleaned up and better documented.

**Please note** that ten topology tests (1 plain, 9 with MPI) are still failing with this PR in place. As it stands (at least to my current knowledge), they have nothing to do with the connection checks as this refactoring did not change anything for them and I really have no clue what else the checks could  be doing wrong at this point.

I understand that the investigation of this is extremely tedious and time consuming. If all else fails, we could have a code staring VC next week.