### PR TITLE
Restructure get - get only returns node information, spatial returns spatial information

### DIFF
--- a/lib/sli/nest-init.sli
+++ b/lib/sli/nest-init.sli
@@ -186,6 +186,11 @@ def
   0 get_g_i GetStatus exch get_d_a
 } def
 
+% Get metadata values of GIDCollection
+/GetMetadata [/gidcollectiontype]
+  /GetMetadata_g load
+def
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Slicing of GIDCollections with Take

--- a/lib/sli/nest-init.sli
+++ b/lib/sli/nest-init.sli
@@ -96,7 +96,7 @@ def
   /status_dict << >> def
 
   size 1 neq
-  { % If not a layer or single GIDCollection. We have a list of dictionaries.
+  { % If not a single value GIDCollection. We have a list of dictionaries.
   
     % The first thing we do is set the keys in the dictionary based on the
     % first GID in the GIDCollection, and set the corresponding value in an
@@ -158,23 +158,15 @@ def
 % Get parameter value of all GIDs in GIDCollection
 /get [/gidcollectiontype /literaltype]
 {
-  exch dup size 1 eq
+  /value Set
+  /gidcoll Set
+
+  gidcoll size 1 eq
   { % if size == 1
-    /GIDColl Set
-    /value Set
-    GIDColl GetStatus 0 get value get
+    gidcoll GetStatus 0 get value get
   }
   { % if size > 1
-    exch
-    /value Set
-
-    GetStatus size 1 neq
-    { % if not a layer
-      { value get } Map
-    }
-    { % if a layer
-      0 get value get
-    } ifelse
+    gidcoll GetStatus { value get } Map
   } ifelse
 } def
 

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -279,7 +279,6 @@ const Name next_readout_time( "next_readout_time" );
 const Name NMDA( "NMDA" );
 const Name no_synapses( "no_synapses" );
 const Name node_uses_wfr( "node_uses_wfr" );
-const Name nodes( "nodes" );
 const Name noise( "noise" );
 const Name noisy_rate( "noisy_rate" );
 const Name num_connections( "num_connections" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -299,7 +299,6 @@ extern const Name next_readout_time;
 extern const Name NMDA;
 extern const Name no_synapses;
 extern const Name node_uses_wfr;
-extern const Name nodes;
 extern const Name noise;
 extern const Name noisy_rate;
 extern const Name num_connections;

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -293,37 +293,15 @@ NestModule::GetStatus_gFunction::execute( SLIInterpreter* i ) const
   size_t gc_size = gc->size();
   ArrayDatum result;
 
-  GIDCollectionMetadataPTR meta = gc->get_metadata();
-  if ( meta.valid() )
+  result.reserve( gc_size );
+
+  for ( GIDCollection::const_iterator it = gc->begin(); it < gc->end(); ++it )
   {
-    DictionaryDatum dict = DictionaryDatum( new Dictionary );
-    meta->get_status( dict );
-
-    ( *dict )[ names::network_size ] = gc_size;
-
-    GIDCollectionPrimitive* gcp =
-      dynamic_cast< GIDCollectionPrimitive* >( &( *gc ) );
-    assert( gcp != 0 && "object must be a GIDCollectionPrimitive" );
-
-    GIDCollectionDatum new_gc =
-      GIDCollectionDatum( new GIDCollectionPrimitive( *gcp ) );
-    new_gc->set_metadata( GIDCollectionMetadataPTR( 0 ) );
-    ( *dict )[ names::nodes ] = new_gc;
-
-    result.reserve( 1 );
+    index node_id = ( *it ).gid;
+    DictionaryDatum dict = get_node_status( node_id );
     result.push_back( dict );
   }
-  else
-  {
-    result.reserve( gc_size );
 
-    for ( GIDCollection::const_iterator it = gc->begin(); it < gc->end(); ++it )
-    {
-      index node_id = ( *it ).gid;
-      DictionaryDatum dict = get_node_status( node_id );
-      result.push_back( dict );
-    }
-  }
   i->OStack.pop();
   i->OStack.push( result );
   i->EStack.pop();

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -388,6 +388,35 @@ NestModule::GetStatus_aFunction::execute( SLIInterpreter* i ) const
 }
 
 void
+NestModule::GetMetadata_gFunction::execute( SLIInterpreter* i ) const
+{
+  i->assert_stack_load( 1 );
+
+  GIDCollectionDatum gc = getValue< GIDCollectionDatum >( i->OStack.pick( 0 ) );
+  if ( not gc->valid() )
+  {
+    throw KernelException( "InvalidGIDCollection" );
+  }
+
+  GIDCollectionMetadataPTR meta = gc->get_metadata();
+  if ( not meta.valid() )
+  {
+    throw KernelException( "InvalidGIDCollection" );
+  }
+
+  size_t gc_size = gc->size();
+
+  DictionaryDatum dict = DictionaryDatum( new Dictionary );
+  meta->get_status( dict );
+
+  ( *dict )[ names::network_size ] = gc_size;
+
+  i->OStack.pop();
+  i->OStack.push( dict );
+  i->EStack.pop();
+}
+
+void
 NestModule::GetKernelStatus_Function::execute( SLIInterpreter* i ) const
 {
   DictionaryDatum dict = get_kernel_status();
@@ -1720,8 +1749,8 @@ NestModule::init( SLIInterpreter* i )
   i->createcommand( "GetStatus_i", &getstatus_ifunction );
   i->createcommand( "GetStatus_C", &getstatus_Cfunction );
   i->createcommand( "GetStatus_a", &getstatus_afunction );
+  i->createcommand( "GetMetadata_g", &getmetadata_gfunction );
   i->createcommand( "GetKernelStatus", &getkernelstatus_function );
-
 
   i->createcommand( "GetConnections_D", &getconnections_Dfunction );
   i->createcommand( "cva_C", &cva_cfunction );

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -382,12 +382,10 @@ NestModule::GetMetadata_gFunction::execute( SLIInterpreter* i ) const
     throw KernelException( "InvalidGIDCollection" );
   }
 
-  size_t gc_size = gc->size();
-
   DictionaryDatum dict = DictionaryDatum( new Dictionary );
   meta->get_status( dict );
 
-  ( *dict )[ names::network_size ] = gc_size;
+  ( *dict )[ names::network_size ] = gc->size();
 
   i->OStack.pop();
   i->OStack.push( dict );

--- a/nestkernel/nestmodule.h
+++ b/nestkernel/nestmodule.h
@@ -155,6 +155,12 @@ public:
     void execute( SLIInterpreter* ) const;
   } getstatus_afunction;
 
+  class GetMetadata_gFunction : public SLIFunction
+  {
+  public:
+    void execute( SLIInterpreter* ) const;
+  } getmetadata_gfunction;
+
   class GetKernelStatus_Function : public SLIFunction
   {
   public:

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -210,7 +210,7 @@ def SetStatus(nodes, params, val=None):
         return
 
     if (isinstance(params, dict) and isinstance(nodes, nest.GIDCollection) and
-            nodes.get('local')):
+            nodes[0].get('local')):
         for k, v in params.items():
             if isinstance(v, nest.Parameter):
                 params[k] = [v.get_value() for _ in range(len(nodes))]

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -211,25 +211,25 @@ def SetStatus(nodes, params, val=None):
 
     if (isinstance(params, dict) and isinstance(nodes, nest.GIDCollection) and
             nodes[0].get('local')):
-        for k, v in params.items():
-            if isinstance(v, nest.Parameter):
-                params[k] = [v.get_value() for _ in range(len(nodes))]
+        for key, vals in params.items():
+            if isinstance(vals, nest.Parameter):
+                params[key] = [vals.get_value() for _ in range(len(nodes))]
 
-        contains_list = [is_iterable(v) and not
-                         is_iterable(nest.GetStatus(nodes[0], k)[0])
-                         for k, v in params.items()]
+        contains_list = [is_iterable(vals) and not
+                         is_iterable(nest.GetStatus(nodes[0], key)[0])
+                         for key, vals in params.items()]
         contains_list = max(contains_list)
 
         if contains_list:
             temp_param = [{} for _ in range(len(nodes))]
 
-            for k, v in params.items():
-                if not is_iterable(v):
-                    for d in temp_param:
-                        d[k] = v
+            for key, vals in params.items():
+                if not is_iterable(vals):
+                    for tmp_dict in temp_param:
+                        tmp_dict[key] = vals
                 else:
-                    for i, d in enumerate(temp_param):
-                        d[k] = v[i]
+                    for i, tmp_dict in enumerate(temp_param):
+                        tmp_dict[key] = vals[i]
             params = temp_param
 
     if val is not None and is_literal(params):

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -455,24 +455,25 @@ class GIDCollection(object):
         """
 
         if isinstance(params, dict) and self[0].get('local'):
-            for k, v in params.items():
-                if isinstance(v, Parameter):
-                    params[k] = [v.get_value() for _ in range(len(self))]
+            for key, vals in params.items():
+                if isinstance(vals, Parameter):
+                    params[key] = [vals.get_value() for _ in range(len(self))]
 
-            contains_list = [is_iterable(v) and not is_iterable(self[0].get(k))
-                             for k, v in params.items()]
+            contains_list = [is_iterable(vals) and not
+                             is_iterable(self[0].get(key))
+                             for key, vals in params.items()]
             contains_list = max(contains_list)
 
             if contains_list:
                 temp_param = [{} for _ in range(self.__len__())]
 
-                for k, v in params.items():
-                    if not is_iterable(v):
+                for key, vals in params.items():
+                    if not is_iterable(vals):
                         for d in temp_param:
-                            d[k] = v
+                            d[key] = vals
                     else:
                         for i, d in enumerate(temp_param):
-                            d[k] = v[i]
+                            d[key] = vals[i]
                 params = temp_param
 
         if val is not None and nest.is_literal(params):

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -144,6 +144,9 @@ class GIDCollection(object):
             gc = nest.sli_func('cvgidcollection', data)
             self._datum = gc._datum
 
+        # Spatial values for layers.
+        self.spatial = None
+
     def __iter__(self):
         return GIDCollectionIterator(self)
 
@@ -195,6 +198,12 @@ class GIDCollection(object):
 
     def __str__(self):
         return nest.sli_func('pcvs', self._datum)
+
+    def set_spatial(self):
+        """
+        set spatial data to self.spatial
+        """
+        self.spatial = nest.sli_func('GetMetadata', self._datum)
 
     def get(self, *params, **kwargs):
         """

--- a/topology/pynest/hl_api.py
+++ b/topology/pynest/hl_api.py
@@ -938,23 +938,22 @@ def FindNearestElement(layer, locations, find_all=False):
         locations = (locations, )
 
     result = []
-    nodes = layer.get('nodes')
 
     for loc in locations:
         d = Distance(numpy.array(loc), layer)
 
         if not find_all:
             dx = numpy.argmin(d)  # finds location of one minimum
-            result.append(nodes[dx].get('global_id'))
+            result.append(layer[dx].get('global_id'))
         else:
             mingids = list(layer[:1])
             minval = d[0]
             for idx in range(1, len(layer)):
                 if d[idx] < minval:
-                    mingids = [nodes[idx].get('global_id')]
+                    mingids = [layer[idx].get('global_id')]
                     minval = d[idx]
                 elif numpy.abs(d[idx] - minval) <= 1e-14 * minval:
-                    mingids.append(nodes[idx].get('global_id'))
+                    mingids.append(layer[idx].get('global_id'))
             result.append(tuple(mingids))
 
     return tuple(result)
@@ -1325,7 +1324,7 @@ def GetTargetPositions(sources, tgt_layer, syn_model=None):
 
     # Find positions to all nodes in target layer
     pos_all_tgts = GetPosition(tgt_layer)
-    first_tgt_gid = tgt_layer[0].get('nodes').get('global_id')
+    first_tgt_gid = tgt_layer[0].get('global_id')
 
     connections = nest.GetConnections(sources, tgt_layer,
                                       synapse_model=syn_model)

--- a/topology/pynest/hl_api.py
+++ b/topology/pynest/hl_api.py
@@ -473,7 +473,9 @@ def CreateLayer(specs):
     elements = specs['elements']
     hlh.model_deprecation_warning(elements)
 
-    return nest.sli_func('CreateLayer', specs)
+    layer = nest.sli_func('CreateLayer', specs)
+    layer.set_spatial()
+    return layer
 
 
 def ConnectLayers(pre, post, projections):
@@ -1171,7 +1173,7 @@ def FindCenterElement(layer):
     if not isinstance(layer, nest.GIDCollection):
         raise nest.NESTError("layer must be a GIDCollection")
 
-    return FindNearestElement(layer, nest.GetStatus(layer[:1])[0]['center'])[0]
+    return FindNearestElement(layer, layer.spatial['center'])[0]
 
 
 def GetTargetNodes(sources, tgt_layer, syn_model=None):
@@ -1425,14 +1427,14 @@ def PlotLayer(layer, fig=None, nodecolor='b', nodesize=20):
         raise ValueError("layer must be a GIDCollection.")
 
     # get layer extent
-    ext = nest.GetStatus(layer)[0]['extent']
+    ext = layer.spatial['extent']
 
     if len(ext) == 2:
         # 2D layer
 
         # get layer extent and center, x and y
         xext, yext = ext
-        xctr, yctr = nest.GetStatus(layer)[0]['center']
+        xctr, yctr = layer.spatial['center']
 
         # extract position information, transpose to list of x and y pos
         xpos, ypos = zip(*GetPosition(layer))
@@ -1562,15 +1564,15 @@ def PlotTargets(src_nrn, tgt_layer, syn_type=None, fig=None,
     # get position of source
     srcpos = GetPosition(src_nrn)
 
-    # get layer extent and center, x and y
-    ext = nest.GetStatus(tgt_layer)[0]['extent']
+    # get layer extent
+    ext = tgt_layer.spatial['extent']
 
     if len(ext) == 2:
         # 2D layer
 
         # get layer extent and center, x and y
         xext, yext = ext
-        xctr, yctr = nest.GetStatus(tgt_layer)[0]['center']
+        xctr, yctr = tgt_layer.spatial['center']
 
         if fig is None:
             fig = plt.figure()

--- a/topology/pynest/tests/test_layer_GetStatus_SetStatus.py
+++ b/topology/pynest/tests/test_layer_GetStatus_SetStatus.py
@@ -105,21 +105,19 @@ class GetSetTestCase(unittest.TestCase):
                          (-50., -50., -50., -50., -50.,
                           -50., -50., -50., -50.))
 
-    def test_LayerGet(self):
-        """Test get function on layer GIDCollection."""
+    def test_LayerSpatial(self):
+        """Test spatial parameter on layer GIDCollection."""
 
         ldict = {'elements': 'iaf_psc_alpha', 'rows': 3, 'columns': 3,
                  'extent': [2., 2.], 'edge_wrap': True}
         layer = topo.CreateLayer(ldict)
 
-        center = layer.get('center')
-        columns = layer.get('columns')
-        edge_wrap = layer.get('edge_wrap')
-        extent = layer.get('extent')
-        network_size = layer.get('network_size')
-        nodes = layer.get('nodes')
-        rows = layer.get('rows')
-        columns_rows = layer.get(['columns', 'rows'])
+        center = layer.spatial['center']
+        columns = layer.spatial['columns']
+        edge_wrap = layer.spatial['edge_wrap']
+        extent = layer.spatial['extent']
+        network_size = layer.spatial['network_size']
+        rows = layer.spatial['rows']
 
         self.assertEqual(center, (0.0, 0.0))
         self.assertEqual(columns, 3)
@@ -149,20 +147,19 @@ class GetSetTestCase(unittest.TestCase):
         self.assertEqual(all_values['network_size'], 9)
         self.assertEqual(all_values['rows'], 3)
 
-        # Test get on single element layer
-        nest.ResetKernel()
+    def test_SingleElementLayerSpatial(self):
+        """Test spatial parameter on single element layer."""
+
         ldict = {'elements': 'iaf_psc_alpha', 'rows': 1, 'columns': 1}
         layer = topo.CreateLayer(ldict)
 
         self.assertEqual(len(layer), 1)
-        center = layer.get('center')
-        columns = layer.get('columns')
-        columns_rows = layer.get(['columns', 'rows'])
-        all_values = layer.get()
+        center = layer.spatial['center']
+        columns = layer.spatial['columns']
+        all_values = layer.spatial
 
         self.assertEqual(center, (0., 0.))
         self.assertEqual(columns, 1)
-        self.assertEqual(columns_rows, {'columns': 1, 'rows': 1})
         self.assertEqual(all_values['center'], (0.0, 0.0))
 
     @unittest.skipIf(not HAVE_PANDAS, 'Pandas package is not available')

--- a/topology/pynest/tests/test_layer_GetStatus_SetStatus.py
+++ b/topology/pynest/tests/test_layer_GetStatus_SetStatus.py
@@ -27,65 +27,11 @@ import unittest
 import nest
 import nest.topology as topo
 
-try:
-    import pandas
-    import pandas.util.testing as pt
-    HAVE_PANDAS = True
-except ImportError:
-    HAVE_PANDAS = False
-
 
 class GetSetTestCase(unittest.TestCase):
 
     def setUp(self):
         nest.ResetKernel()
-
-    def test_LayerGetStatus(self):
-        """Test GetStatus on layer GIDCollection."""
-
-        ldict = {'elements': 'iaf_psc_alpha', 'rows': 3, 'columns': 3,
-                 'extent': [2., 2.], 'edge_wrap': True}
-        layer = topo.CreateLayer(ldict)
-
-        center = nest.GetStatus(layer)[0]['center']
-        columns = nest.GetStatus(layer)[0]['columns']
-        edge_wrap = nest.GetStatus(layer)[0]['edge_wrap']
-        extent = nest.GetStatus(layer)[0]['extent']
-        network_size = nest.GetStatus(layer)[0]['network_size']
-        nodes = nest.GetStatus(layer)[0]['nodes']
-        rows = nest.GetStatus(layer)[0]['rows']
-
-        self.assertEqual(center, (0., 0.))
-        self.assertEqual(columns, 3)
-        self.assertTrue(edge_wrap)
-        self.assertEqual(extent, (2., 2.))
-        self.assertEqual(network_size, 9)
-        self.assertEqual(rows, 3)
-        self.assertTrue(isinstance(nodes, nest.GIDCollection))
-
-        n = [gid for gid in nodes]
-        self.assertEqual(n, [1, 2, 3, 4, 5, 6, 7, 8, 9])
-        self.assertEqual(len(nest.GetStatus(nodes)), len(layer))
-        self.assertEqual(nest.GetStatus(nodes, 'V_m'),
-                         (-70., -70., -70., -70., -70.,
-                          -70., -70., -70., -70.))
-
-        self.assertEqual(len(nest.GetStatus(layer)), 1)
-
-        self.assertTrue('V_m' not in nest.GetStatus(layer)[0])
-
-        nest.ResetKernel()
-        ldict = {'elements': 'iaf_psc_alpha', 'rows': 2, 'columns': 4,
-                 'extent': [4., 4.], 'edge_wrap': False}
-        lyr = topo.CreateLayer(ldict)
-
-        cntr = nest.GetStatus(lyr, 'center')
-        ext = nest.GetStatus(lyr, keys=['extent'])
-        rows_cols = nest.GetStatus(lyr, keys=['rows', 'columns'])
-
-        self.assertEqual(cntr, ((0.0, 0.0),))
-        self.assertEqual(ext, (((4., 4.),),))
-        self.assertEqual(rows_cols, ((2, 4),))
 
     def test_LayerSetStatus(self):
         """Test SetStatus on layer GIDCollection."""
@@ -97,11 +43,9 @@ class GetSetTestCase(unittest.TestCase):
         with self.assertRaises(nest.NESTError):
             nest.SetStatus(layer, {'center': [1., 1.]})
 
-        nodes = nest.GetStatus(layer)[0]['nodes']
-        nest.SetStatus(nodes, 'V_m', -50.)
+        nest.SetStatus(layer, 'V_m', -50.)
 
-        nodes2 = nest.GetStatus(layer)[0]['nodes']
-        self.assertEqual(nest.GetStatus(nodes2, 'V_m'),
+        self.assertEqual(nest.GetStatus(layer, 'V_m'),
                          (-50., -50., -50., -50., -50.,
                           -50., -50., -50., -50.))
 
@@ -125,21 +69,14 @@ class GetSetTestCase(unittest.TestCase):
         self.assertEqual(extent, (2., 2.))
         self.assertEqual(network_size, 9)
         self.assertEqual(rows, 3)
-        self.assertTrue(isinstance(nodes, nest.GIDCollection))
-        self.assertEqual(columns_rows, {'columns': 3, 'rows': 3})
 
-        n = [gid for gid in nodes]
-        self.assertEqual(n, [1, 2, 3, 4, 5, 6, 7, 8, 9])
-        self.assertEqual(nodes.get('V_m'),
+        self.assertEqual(layer.get('V_m'),
                          (-70., -70., -70., -70., -70.,
                           -70., -70., -70., -70.))
 
-        with self.assertRaises(KeyError):
-            layer.get('V_m')
-
         # Test get all values
-        all_values = layer.get()
-        self.assertEqual(len(all_values.keys()), 7)
+        all_values = layer.spatial
+        self.assertEqual(len(all_values.keys()), 6)
         self.assertEqual(all_values['center'], (0.0, 0.0))
         self.assertEqual(all_values['columns'], 3)
         self.assertTrue(all_values['edge_wrap'])
@@ -162,34 +99,13 @@ class GetSetTestCase(unittest.TestCase):
         self.assertEqual(columns, 1)
         self.assertEqual(all_values['center'], (0.0, 0.0))
 
-    @unittest.skipIf(not HAVE_PANDAS, 'Pandas package is not available')
-    def test_LayerGet_pandas(self):
-        """Test get function on layer GIDCollection with Pandas output."""
+    def test_LayerGet(self):
+        """Test get function on layer GIDCollection"""
 
-        ldict = {'elements': 'iaf_psc_alpha', 'rows': 3, 'columns': 3,
-                 'extent': [2., 2.], 'edge_wrap': True}
+        ldict = {'elements': 'iaf_psc_alpha', 'rows': 2, 'columns': 2}
         layer = topo.CreateLayer(ldict)
 
-        # Literal argument
-        value = layer.get('center', output='pandas')
-        pt.assert_frame_equal(value, pandas.DataFrame({'center': [(0.0, 0.0)]},
-                                                      columns=['layer']))
-
-        # Array argument
-        value = layer.get(['center', 'extent'], output='pandas')
-        pt.assert_frame_equal(value, pandas.DataFrame({'center': [(0.0, 0.0)],
-                                                       'extent': [(1.0, 1.0)]},
-                                                      columns=['layer']))
-
-        # Get all values
-        all_values = layer.get(output='pandas')
-        self.assertEqual(all_values.shape, (7, 1))
-        self.assertEqual(all_values['layer']['center'], (0.0, 0.0))
-        self.assertEqual(all_values['layer']['columns'], 3)
-        self.assertTrue(all_values['layer']['edge_wrap'])
-        self.assertEqual(all_values['layer']['extent'], (2., 2.))
-        self.assertEqual(all_values['layer']['network_size'], 9)
-        self.assertEqual(all_values['layer']['rows'], 3)
+        self.assertEqual(layer.get('V_m'), (-70., -70., -70., -70.))
 
     def test_LayerSet(self):
         """Test set function on layer GIDCollection."""
@@ -198,14 +114,12 @@ class GetSetTestCase(unittest.TestCase):
                  'extent': [2., 2.], 'edge_wrap': True}
         layer = topo.CreateLayer(ldict)
 
-        with self.assertRaises(nest.NESTError):
+        with self.assertRaises(KeyError):
             layer.set({'center': [1., 1.]})
 
-        nodes = layer.get('nodes')
-        nodes.set('V_m', -50.)
+        layer.set('V_m', -50.)
 
-        nodes2 = layer.get('nodes')
-        self.assertEqual(nodes2.get('V_m'),
+        self.assertEqual(layer.get('V_m'),
                          (-50., -50., -50., -50., -50.,
                           -50., -50., -50., -50.))
 

--- a/topology/pynest/tests/test_spatial_kernels.py
+++ b/topology/pynest/tests/test_spatial_kernels.py
@@ -229,7 +229,7 @@ class SpatialTester(object):
             self._ls = topo.CreateLayer(ldict_s)
             self._lt = topo.CreateLayer(ldict_t)
             cntr = topo.FindCenterElement(self._ls)
-            indx = cntr - self._ls[0].get('nodes').get('global_id')
+            indx = cntr - self._ls[0].get('global_id')
             self._driver = self._ls[indx]
 
     def _connect(self):


### PR DESCRIPTION
This addresses parts of #8. `get` will now always return node information. To get spatial information on PyNEST level, use `.spatial`. Note that `spatial` is not a function, but a dictionary. If the `GIDCollection` is not a layer, `spatial` returns `None`.

On SLI and C++ level, I have added a `GetMetadata` function, because I think it is better to have one general function that returns metadata, and then we can call this function for all metadata-get functions, like I have done with `spatial` on PyNEST level.

`GetStatus` will now only return node information, both on Python, SLI and C++ level. This means that it is **no longer possible** to get spatial (topology) information by calling `nest.GetStatus(layer)`. This is quite a difference from master, where one can call `nest.GetStatus(layer, topology)` and get the spatial information. I can add a check for `spatial` as a key to `GetStatus` and then return spatial information if that is better? There are not that many people who will know about `get` and `spatial` who might get confused when it is no longer possible to get spatial information from `GetStatus`. On the other hand, this might force people to start using `get` and `spatial`.

This PR restructures PyNEST's `get` function a lot. Most notably for `GIDCollection`, but also for the `Connectome`. I have added functions `_restructure_data` to restructure `Connectome`s `get` output, `_get_params_is_string` that get parameters from nodes if params is a string, and `_get_hierarchical_addressing` which handles hierarchical case. `pandas_output` is handled by the end of `get`. Unfortunately, `Connectome`s `get` and `GIDCollection`s `get` is handled a little differently, so not that much code could be reused.