### PR TITLE
Updates for primitive slicing: correction of endpoint, updated tests

### DIFF
--- a/nestkernel/gid_collection.cpp
+++ b/nestkernel/gid_collection.cpp
@@ -458,8 +458,8 @@ GIDCollectionComposite::GIDCollectionComposite(
   , step_( step )
   , start_part_( 0 )
   , start_offset_( start )
-  , stop_part_( 0 )
-  , stop_offset_( stop )
+  , stop_part_( stop == primitive.size() )
+  , stop_offset_( stop == primitive.size() ? 0 : stop )
 {
   parts_.reserve( 1 );
   parts_.push_back( primitive );

--- a/pynest/nest/tests/test_GIDCollection.py
+++ b/pynest/nest/tests/test_GIDCollection.py
@@ -262,8 +262,8 @@ class TestGIDCollection(unittest.TestCase):
         n_c = nest.Create('iaf_psc_delta', num_c)
 
         nodes = n_a + n_c
-        nodes = nodes[::2]
-        nodes_list = list(nodes)
+        nodes_step = nodes[::2]
+        nodes_list = list(nodes_step)
         compare_list = (list(range(1, 11))[::2] + list(range(26, 55))[::2])
         self.assertEqual(nodes_list, compare_list)
 
@@ -271,31 +271,23 @@ class TestGIDCollection(unittest.TestCase):
         self.assertEqual(nodes_list[5], 26)
         self.assertEqual(nodes_list[19], 54)
 
-        # Rebuild GIDCollection as a composite to be able to slice
         ngc = nest.GIDCollection(nodes_list)
-        self.assertEqual(nodes, ngc)
+        self.assertEqual(nodes_step, ngc)
 
-        n_slice_first = ngc[:10]
-        n_slice_middle = ngc[2:7]
-        n_slice_middle_jump = ngc[2:12:2]
+        n_slice_first = nodes[:10]
+        n_slice_middle = nodes[2:7]
+        n_slice_middle_jump = nodes[2:12:2]
 
         n_list_first = list(n_slice_first)
         n_list_middle = list(n_slice_middle)
         n_list_middle_jump = list(n_slice_middle_jump)
 
-        compare_list_first = [1, 3, 5, 7, 9, 26, 28, 30, 32, 34]
-        compare_list_middle = [5, 7, 9, 26, 28]
-        compare_list_middle_jump = [5, 9, 28, 32, 36]
+        compare_list_first = list(range(1, 11))
+        compare_list_middle = list(range(3, 8))
+        compare_list_middle_jump = [3, 5, 7, 9, 26]
         self.assertEqual(n_list_first, compare_list_first)
         self.assertEqual(n_list_middle, compare_list_middle)
         self.assertEqual(n_list_middle_jump, compare_list_middle_jump)
-
-        self.assertTrue(5 in nodes)
-        self.assertTrue(44 in nodes)
-        self.assertFalse(6 in nodes)
-        self.assertFalse(10 in nodes)
-        self.assertFalse(15 in nodes)
-        self.assertFalse(25 in nodes)
 
     def test_composite_wrong_slice(self):
         """

--- a/pynest/nest/tests/test_GIDCollection.py
+++ b/pynest/nest/tests/test_GIDCollection.py
@@ -261,27 +261,31 @@ class TestGIDCollection(unittest.TestCase):
         n_b = nest.Create('iaf_psc_alpha', num_b)
         n_c = nest.Create('iaf_psc_delta', num_c)
 
-        n_a = n_a[::2]
         nodes = n_a + n_c
-        nodes_list = [x for x in nodes]
-        compare_list = (list([x for x in range(1, 11) if x % 2 != 0]) +
-                        list(range(num_a + num_b + 1,
-                                   num_a + num_b + num_c + 1)))
+        nodes = nodes[::2]
+        nodes_list = list(nodes)
+        compare_list = (list(range(1, 11))[::2] + list(range(26, 55))[::2])
         self.assertEqual(nodes_list, compare_list)
 
-        self.assertEqual(nodes[2], nest.GIDCollection([5]))
-        self.assertEqual(nodes[5], nest.GIDCollection([26]))
-        self.assertEqual(nodes[34], nest.GIDCollection([55]))
+        self.assertEqual(nodes_list[2], 5)
+        self.assertEqual(nodes_list[5], 26)
+        self.assertEqual(nodes_list[19], 54)
 
-        n_slice_first = nodes[:10]
-        n_slice_middle = nodes[2:7]
-        n_slice_middle_jump = nodes[2:12:2]
-        n_list_first = [x for x in n_slice_first]
-        n_list_middle = [x for x in n_slice_middle]
-        n_list_middle_jump = [x for x in n_slice_middle_jump]
-        compare_list_first = [1, 3, 5, 7, 9, 26, 27, 28, 29, 30]
-        compare_list_middle = [5, 7, 9, 26, 27]
-        compare_list_middle_jump = [5, 9, 27, 29, 31]
+        # Rebuild GIDCollection as a composite to be able to slice
+        ngc = nest.GIDCollection(nodes_list)
+        self.assertEqual(nodes, ngc)
+
+        n_slice_first = ngc[:10]
+        n_slice_middle = ngc[2:7]
+        n_slice_middle_jump = ngc[2:12:2]
+
+        n_list_first = list(n_slice_first)
+        n_list_middle = list(n_slice_middle)
+        n_list_middle_jump = list(n_slice_middle_jump)
+
+        compare_list_first = [1, 3, 5, 7, 9, 26, 28, 30, 32, 34]
+        compare_list_middle = [5, 7, 9, 26, 28]
+        compare_list_middle_jump = [5, 9, 28, 32, 36]
         self.assertEqual(n_list_first, compare_list_first)
         self.assertEqual(n_list_middle, compare_list_middle)
         self.assertEqual(n_list_middle_jump, compare_list_middle_jump)
@@ -292,9 +296,6 @@ class TestGIDCollection(unittest.TestCase):
         self.assertFalse(10 in nodes)
         self.assertFalse(15 in nodes)
         self.assertFalse(25 in nodes)
-
-        ngc = nest.GIDCollection(nodes_list)
-        self.assertEqual(nodes, ngc)
 
     def test_composite_wrong_slice(self):
         """

--- a/testsuite/unittests/test_gid_collection.sli
+++ b/testsuite/unittests/test_gid_collection.sli
@@ -476,13 +476,13 @@ pop pop
   (More complex Take example, checking result in various ways) M_PROGRESS message
   ResetKernel
 
-  /iaf_psc_alpha 10 Create [1 10 2] Take
+  /iaf_psc_alpha 10 Create
   /iaf_psc_exp 15 Create pop
   /iaf_psc_delta 30 Create
   join
-  10 Take /gc Set
+  [1 20 2] Take /gc Set
   
-  /expected [1 3 5 7 9 26 27 28 29 30] def
+  /expected [1 3 5 7 9 26 28 30 32 34] def
   
   gc cva expected eq      % loops at C++ level
   gc { } Map expected eq  % loops at SLI level


### PR DESCRIPTION
Endpoints when slicing primitives with step had to be corrected. Furthermore, tests no longer try to join primitives that are sliced with step, as this is no longer supported (see #16). 